### PR TITLE
healthcheck

### DIFF
--- a/common/src/main/scala/org/allenai/aristomini/server/HealthChecker.scala
+++ b/common/src/main/scala/org/allenai/aristomini/server/HealthChecker.scala
@@ -1,0 +1,14 @@
+package org.allenai.aristomini.server
+
+import com.codahale.metrics.health.HealthCheck
+import com.codahale.metrics.health.HealthCheck.Result
+
+/** A dummy health checker that always reports healthy.
+  *
+  * Intended to suppress health check warnings on server startup.
+  */
+object HealthChecker extends HealthCheck {
+  override def check = {
+    Result.healthy()
+  }
+}

--- a/common/src/main/scala/org/allenai/aristomini/server/ServerBase.scala
+++ b/common/src/main/scala/org/allenai/aristomini/server/ServerBase.scala
@@ -17,5 +17,6 @@ abstract class ServerBase(service: Object, name: String = "Server")
       case services: Seq[_] => services.foreach(environment.jersey().register(_))
       case _ => environment.jersey().register(service)
     }
+    environment.healthChecks().register("health-checker", HealthChecker)
   }
 }


### PR DESCRIPTION
Before this change each of the servers printed this on startup:

```
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!    THIS APPLICATION HAS NO HEALTHCHECKS. THIS MEANS YOU WILL NEVER KNOW      !
!     IF IT DIES IN PRODUCTION, WHICH MEANS YOU WILL NEVER KNOW IF YOU'RE      !
!    LETTING YOUR USERS DOWN. YOU SHOULD ADD A HEALTHCHECK FOR EACH OF YOUR    !
!         APPLICATION'S DEPENDENCIES WHICH FULLY (BUT LIGHTLY) TESTS IT.       !
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```

After this change, it does not.

In addition, I can request http://localhost:9001/healthcheck and see my `health-checker` status:

```
{"deadlocks":{"healthy":true},"health-checker":{"healthy":true}}
```
