### PR TITLE
optimizing the es index, and not using DFS_QUERY_THEN_FETCH

### DIFF
--- a/solvers/textsearch/src/main/scala/org/allenai/aristomini/solver/textsearch/README.md
+++ b/solvers/textsearch/src/main/scala/org/allenai/aristomini/solver/textsearch/README.md
@@ -35,7 +35,7 @@ These numbers are reported directly in the response: `{"choiceConfidence":{"A":0
 
 To use the Text Search Solver, you need to populate a local Elasticsearch index with sentences.
 
-### Set up a local Elasticsearch server
+### Start a local Elasticsearch server
 
 Download [Elasticsearch 2.4.1](https://www.elastic.co/downloads/past-releases/elasticsearch-2-4-1) and run the server locally with out-of-the-box defaults.
 
@@ -46,6 +46,35 @@ wget https://download.elastic.co/elasticsearch/release/org/elasticsearch/distrib
 unzip elasticsearch-2.4.1.zip
 cd elasticsearch-2.4.1
 bin/elasticsearch
+```
+
+### Configure your local Elasticsearch server
+
+The default settings for Elasticsearch are meant for production use, involving replication and sharding. In the case of this simple solver, we'll be running it on a single machine, so the default number of replicas and shards have to be adjusted.
+
+In addition, we want to explicitly declare that the index `knowledge` will contain documents with property `body` that should be indexed using the [Snowball analyzer](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/analysis-snowball-tokenfilter.html) for word stemming.
+
+To configure your running Elasticsearch server with these settings, issue this command:
+
+```
+curl -XPUT 'http://localhost:9200/knowledge' -d '
+{
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 0
+  },
+  "mappings": {
+    "sentence": {
+      "dynamic": "false",
+      "properties": {
+        "body": {
+          "analyzer": "snowball",
+          "type": "string"
+        }
+      }
+    }
+  }
+}'
 ```
 
 ### Populate your Elasticsearch server with interesting sentences
@@ -64,9 +93,10 @@ freely available. Save it into a file like `/tmp/allaboutanimals.txt`.
    cat /tmp/allaboutanimals.txt | bin/insert-text-to-elasticsearch.py
    ```
    
-3. Watch insertion progress:
+3. Watch progress and wait for the insertion program to conclude:
    ```
    Posted 7182 documents (570154 bytes) to http://localhost:9200/knowledge/sentence/_bulk. Elasticsearch errors = False
+   Documents posted: 7182
    ```
 
 ### Start the solver server

--- a/solvers/textsearch/src/main/scala/org/allenai/aristomini/solver/textsearch/TextSearchSolver.scala
+++ b/solvers/textsearch/src/main/scala/org/allenai/aristomini/solver/textsearch/TextSearchSolver.scala
@@ -58,7 +58,6 @@ object TextSearchSolver extends SolverBase {
     // submit the query and get the results
     val searchHits: SearchHits = esClient
         .prepareSearch(indexName)
-        .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
         .setQuery(QueryBuilders.matchQuery(fieldName, queryText))
         .setSize(topN)
         .get.getHits


### PR DESCRIPTION
Following advice from Colin, here's an explicit index configuration. Looks like a bit of good and bad, with `AI2-Elementary-NDMC-Feb2016-Dev` benefiting the most.

Using SimpleWikipedia-all-v1.txt:

```
                                                                             Before:                                           After:
Exam: data/questions/AI2-8thGr-NDMC-Feb2016-Dev.jsonl        (65  questions) Score:  24 correct /  65 answered = 36% correct.  Score:  23 correct /  65 answered = 35% correct.
Exam: data/questions/AI2-8thGr-NDMC-Feb2016-Train.jsonl      (293 questions) Score: 113 correct / 293 answered = 38% correct.  Score: 113 correct / 293 answered = 38% correct.
Exam: data/questions/AI2-Elementary-NDMC-Feb2016-Dev.jsonl   (84  questions) Score:  24 correct /  84 answered = 28% correct.  Score:  34 correct /  84 answered = 40% correct.
Exam: data/questions/AI2-Elementary-NDMC-Feb2016-Train.jsonl (432 questions) Score: 147 correct / 432 answered = 34% correct.  Score: 160 correct / 432 answered = 37% correct.
```

Using simpleWiki-science-sentences.txt:

```
                                                                             Before:                                           After:
Exam: data/questions/AI2-8thGr-NDMC-Feb2016-Dev.jsonl        (65  questions) Score:  21 correct /  65 answered = 32% correct.  Score:  20 correct /  65 answered = 30% correct.
Exam: data/questions/AI2-8thGr-NDMC-Feb2016-Train.jsonl      (293 questions) Score:  93 correct / 293 answered = 31% correct.  Score: 103 correct / 293 answered = 35% correct.
Exam: data/questions/AI2-Elementary-NDMC-Feb2016-Dev.jsonl   (84  questions) Score:  19 correct /  84 answered = 22% correct.  Score:  31 correct /  84 answered = 36% correct.
Exam: data/questions/AI2-Elementary-NDMC-Feb2016-Train.jsonl (432 questions) Score: 136 correct / 432 answered = 31% correct.  Score: 154 correct / 432 answered = 35% correct.
```
